### PR TITLE
change logic to identify Locking-classes in Commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ php:
   - 7.2
 
 env:
-    - SYMFONY_VERSION=lts:^2
     - SYMFONY_VERSION=lts:^3
+    - SYMFONY_VERSION=lts:^4
     - SYMFONY_VERSION=flex:^1
 
 
@@ -14,7 +14,7 @@ matrix:
   fast_finish: true
   include:
     - env:
-        - SYMFONY_VERSION=lts:^2
+        - SYMFONY_VERSION=lts:^3
         - dependencies=lowest
 
     - env:
@@ -37,7 +37,7 @@ before_install:
 before_script:
   - phpenv config-add travis.php.ini
   - travis_wait composer require symfony/${SYMFONY_VERSION} --prefer-source --no-update -v
-  - travis_wait composer install --prefer-source
+  - if [ "$dependencies" != "lowest" ]; then travis_wait composer install --prefer-source fi;
   - if [ "$dependencies" = "lowest" ]; then travis_wait composer update --prefer-lowest --prefer-stable -n; fi;
   - mv ~/xdebug.ini /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 before_script:
   - phpenv config-add travis.php.ini
   - travis_wait composer require symfony/${SYMFONY_VERSION} --prefer-source --no-update -v
-  - if [ "$dependencies" != "lowest" ]; then travis_wait composer install --prefer-source fi;
+  - if [ "$dependencies" != "lowest" ]; then travis_wait composer install --prefer-source; fi;
   - if [ "$dependencies" = "lowest" ]; then travis_wait composer update --prefer-lowest --prefer-stable -n; fi;
   - mv ~/xdebug.ini /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
 

--- a/Command/SendNewsLetterCommand.php
+++ b/Command/SendNewsLetterCommand.php
@@ -43,15 +43,18 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID < 30400) {
+        if (class_exists('Symfony\Component\Filesystem\LockHandler')) {
             $lock = new \Symfony\Component\Filesystem\LockHandler($this->getName());
             $unlockedCommand = $lock->lock();
-        } else {
+        } elseif (class_exists('\Symfony\Component\Lock\Store\SemaphoreStore') && class_exists('\Symfony\Component\Lock\Factory')) {
             $store = new \Symfony\Component\Lock\Store\SemaphoreStore();
             $factory = new \Symfony\Component\Lock\Factory($store);
 
             $lock = $factory->createLock($this->getName());
             $unlockedCommand = $lock->acquire();
+        } else {
+            $output->writeln('Unable to identify available Locking classes. Running without locks');
+            $unlockedCommand = true;
         }
 
         if (!$unlockedCommand) {

--- a/Command/SendNotificationsCommand.php
+++ b/Command/SendNotificationsCommand.php
@@ -55,7 +55,6 @@ EOF
             $output->writeln('Unable to identify available Locking classes. Running without locks');
             $unlockedCommand = true;
         }
-        }
 
         if (!$unlockedCommand) {
             $output->writeln('The command is already running in another process.');

--- a/Command/SendNotificationsCommand.php
+++ b/Command/SendNotificationsCommand.php
@@ -42,15 +42,19 @@ EOF
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (\Symfony\Component\HttpKernel\Kernel::VERSION_ID < 30400) {
+        if (class_exists('Symfony\Component\Filesystem\LockHandler')) {
             $lock = new \Symfony\Component\Filesystem\LockHandler($this->getName());
             $unlockedCommand = $lock->lock();
-        } else {
+        } elseif (class_exists('\Symfony\Component\Lock\Store\SemaphoreStore') && class_exists('\Symfony\Component\Lock\Factory')) {
             $store = new \Symfony\Component\Lock\Store\SemaphoreStore();
             $factory = new \Symfony\Component\Lock\Factory($store);
 
             $lock = $factory->createLock($this->getName());
             $unlockedCommand = $lock->acquire();
+        } else {
+            $output->writeln('Unable to identify available Locking classes. Running without locks');
+            $unlockedCommand = true;
+        }
         }
 
         if (!$unlockedCommand) {

--- a/Command/SendNotificationsCommand.php
+++ b/Command/SendNotificationsCommand.php
@@ -65,15 +65,17 @@ EOF
         $failedAddresses = array();
         $sentMails = $this->getContainer()->get('azine_email_notifier_service')->sendNotifications($failedAddresses);
 
-        $output->writeln(date(\DateTime::RFC2822).' : '.str_pad($sentMails, 4, ' ', STR_PAD_LEFT).' emails have been processed.');
+        $output->writeln(date(\DateTime::RFC2822) . ' : ' . str_pad($sentMails, 4, ' ', STR_PAD_LEFT) . ' emails have been processed.');
         if (sizeof($failedAddresses) > 0) {
-            $output->writeln(date(\DateTime::RFC2822).' : '.'The following email-addresses failed:');
+            $output->writeln(date(\DateTime::RFC2822) . ' : ' . 'The following email-addresses failed:');
             foreach ($failedAddresses as $address) {
-                $output->writeln('    '.$address);
+                $output->writeln('    ' . $address);
             }
         }
 
         // (optional) release the lock (otherwise, PHP will do it for you automatically)
-        $lock->release();
+        if (isset($lock) && method_exists($lock, '$release')) {
+            $lock->release();
+        }
     }
 }

--- a/Command/SendNotificationsCommand.php
+++ b/Command/SendNotificationsCommand.php
@@ -65,11 +65,11 @@ EOF
         $failedAddresses = array();
         $sentMails = $this->getContainer()->get('azine_email_notifier_service')->sendNotifications($failedAddresses);
 
-        $output->writeln(date(\DateTime::RFC2822) . ' : ' . str_pad($sentMails, 4, ' ', STR_PAD_LEFT) . ' emails have been processed.');
+        $output->writeln(date(\DateTime::RFC2822).' : '.str_pad($sentMails, 4, ' ', STR_PAD_LEFT).' emails have been processed.');
         if (sizeof($failedAddresses) > 0) {
-            $output->writeln(date(\DateTime::RFC2822) . ' : ' . 'The following email-addresses failed:');
+            $output->writeln(date(\DateTime::RFC2822).' : '.'The following email-addresses failed:');
             foreach ($failedAddresses as $address) {
-                $output->writeln('    ' . $address);
+                $output->writeln('    '.$address);
             }
         }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
+        $treeBuilder = new TreeBuilder("azine_email");
         $rootNode = $treeBuilder->root('azine_email');
 
         $rootNode

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder("azine_email");
+        $treeBuilder = new TreeBuilder('azine_email');
         $rootNode = $treeBuilder->root('azine_email');
 
         $rootNode

--- a/Services/AzineNotifierService.php
+++ b/Services/AzineNotifierService.php
@@ -239,7 +239,7 @@ class AzineNotifierService implements NotifierServiceInterface
         // this is because if the last run started 60min. ago, then the notifications
         // for any recipient have been send after that and would be skipped until the next run.
         // if your cron-job runs every minute, this is not needed.
-        return 	60 * 60 - 3 * 60;
+        return 60 * 60 - 3 * 60;
     }
 
     /**

--- a/Services/AzineTwigSwiftMailer.php
+++ b/Services/AzineTwigSwiftMailer.php
@@ -79,7 +79,7 @@ class AzineTwigSwiftMailer extends TwigSwiftMailer implements TemplateTwigSwiftM
                                     \Twig_Environment $twig,
                                     TranslatorInterface $translator,
                                     TemplateProviderInterface $templateProvider,
-                                    ManagerRegistry $managerRegistry,
+                                    $managerRegistry,
                                     EmailOpenTrackingCodeBuilderInterface $emailOpenTrackingCodeBuilder,
                                     AzineEmailTwigExtension $emailTwigExtension,
                                     array $parameters,

--- a/Services/AzineTwigSwiftMailer.php
+++ b/Services/AzineTwigSwiftMailer.php
@@ -5,7 +5,7 @@ namespace Azine\EmailBundle\Services;
 use Azine\EmailBundle\DependencyInjection\AzineEmailExtension;
 use Azine\EmailBundle\Entity\SentEmail;
 use Azine\EmailUpdateConfirmationBundle\Mailer\EmailUpdateConfirmationMailerInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\UserBundle\Mailer\TwigSwiftMailer;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\File\Exception\FileException;

--- a/Tests/Controller/AzineEmailTemplateControllerTest.php
+++ b/Tests/Controller/AzineEmailTemplateControllerTest.php
@@ -217,8 +217,8 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $sentEmail->setToken($token);
         $repositoryMock = $this->getMockBuilder("Azine\EmailBundle\Entity\Repositories\SentEmailRepository")->disableOriginalConstructor()->setMethods(array('findOneByToken'))->getMock();
         $repositoryMock->expects($this->once())->method('findOneByToken')->will($this->returnValue($sentEmail));
-        $doctrineManagerMock = $this->getMockBuilder("Doctrine\ORM\EntityManagerMock")->disableOriginalConstructor()->getMock();
-        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $doctrineManagerMock = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
+        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $doctrineManagerRegistryMock->expects($this->once())->method('getRepository')->with('AzineEmailBundle:SentEmail')->will($this->returnValue($repositoryMock));
         $securityTokenMock = $this->getMockBuilder("Symfony\Component\Security\Core\Authentication\Token\TokenInterface")->disableOriginalConstructor()->getMock();
         $securityTokenMock->expects($this->exactly(2))->method('getUser')->will($this->returnValue($userMock));
@@ -254,7 +254,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $repositoryMock = $this->getMockBuilder("Azine\EmailBundle\Entity\Repositories\SentEmailRepository")->disableOriginalConstructor()->setMethods(array('findOneByToken'))->getMock();
         $repositoryMock->expects($this->once())->method('findOneByToken')->will($this->returnValue($sentEmail));
         $doctrineManagerMock = $this->getMockBuilder("Doctrine\ORM\EntityManagerMock")->disableOriginalConstructor()->getMock();
-        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $doctrineManagerRegistryMock->expects($this->once())->method('getRepository')->with('AzineEmailBundle:SentEmail')->will($this->returnValue($repositoryMock));
         $securityTokenMock = $this->getMockBuilder("Symfony\Component\Security\Core\Authentication\Token\TokenInterface")->disableOriginalConstructor()->getMock();
         $securityTokenMock->expects($this->once())->method('getUser')->will($this->returnValue(null));

--- a/Tests/Controller/AzineEmailTemplateControllerTest.php
+++ b/Tests/Controller/AzineEmailTemplateControllerTest.php
@@ -218,7 +218,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $repositoryMock = $this->getMockBuilder("Azine\EmailBundle\Entity\Repositories\SentEmailRepository")->disableOriginalConstructor()->setMethods(array('findOneByToken'))->getMock();
         $repositoryMock->expects($this->once())->method('findOneByToken')->will($this->returnValue($sentEmail));
         $doctrineManagerMock = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $doctrineManagerRegistryMock->expects($this->once())->method('getRepository')->with('AzineEmailBundle:SentEmail')->will($this->returnValue($repositoryMock));
         $securityTokenMock = $this->getMockBuilder("Symfony\Component\Security\Core\Authentication\Token\TokenInterface")->disableOriginalConstructor()->getMock();
         $securityTokenMock->expects($this->exactly(2))->method('getUser')->will($this->returnValue($userMock));
@@ -254,7 +254,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $repositoryMock = $this->getMockBuilder("Azine\EmailBundle\Entity\Repositories\SentEmailRepository")->disableOriginalConstructor()->setMethods(array('findOneByToken'))->getMock();
         $repositoryMock->expects($this->once())->method('findOneByToken')->will($this->returnValue($sentEmail));
         $doctrineManagerMock = $this->getMockBuilder("Doctrine\ORM\EntityManagerMock")->disableOriginalConstructor()->getMock();
-        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $doctrineManagerRegistryMock = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $doctrineManagerRegistryMock->expects($this->once())->method('getRepository')->with('AzineEmailBundle:SentEmail')->will($this->returnValue($repositoryMock));
         $securityTokenMock = $this->getMockBuilder("Symfony\Component\Security\Core\Authentication\Token\TokenInterface")->disableOriginalConstructor()->getMock();
         $securityTokenMock->expects($this->once())->method('getUser')->will($this->returnValue(null));

--- a/Tests/Controller/AzineEmailTemplateControllerTest.php
+++ b/Tests/Controller/AzineEmailTemplateControllerTest.php
@@ -124,7 +124,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $this->assertNotContains('<!doctype', $response->getContent());
     }
 
-    public function testWebViewAction_User_access_allowed()
+    public function testWebViewActionUserAccessAllowed()
     {
         $token = 'fdasdfasfafsadf';
         $twigMock = $this->getMockBuilder("Symfony\Bundle\TwigBundle\TwigEngine")->disableOriginalConstructor()->getMock();
@@ -164,7 +164,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $controller->webViewAction($requestMock, $token);
     }
 
-    public function testWebViewAction_Anonymous_access_allowed()
+    public function testWebViewActionAnonymousAccessAllowed()
     {
         $token = 'fdasdfasfafsadf';
         $twigMock = $this->getMockBuilder("Symfony\Bundle\TwigBundle\TwigEngine")->disableOriginalConstructor()->getMock();
@@ -203,7 +203,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */
-    public function testWebViewAction_User_access_denied()
+    public function testWebViewActionUserAccessDenied()
     {
         $token = 'fdasdfasfafsadf';
         $userMail = 'an-other-user@email.com';
@@ -242,7 +242,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
     /**
      * @expectedException \Symfony\Component\Security\Core\Exception\AccessDeniedException
      */
-    public function testWebViewAction_Anonymous_Access_denied()
+    public function testWebViewActionAnonymousAccessDenied()
     {
         $token = 'fdasdfasfafsadf';
         $sentEmail = new SentEmail();
@@ -275,7 +275,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $controller->webViewAction($requestMock, $token);
     }
 
-    public function testWebViewAction_Admin_with_CampaignParams()
+    public function testWebViewActionAdminWithCampaignParams()
     {
         $token = 'fdasdfasfafsadf';
         $twigMock = $this->getMockBuilder("Symfony\Bundle\TwigBundle\TwigEngine")->disableOriginalConstructor()->getMock();
@@ -322,7 +322,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
         $this->assertContains('http://testurl.com/with/?param=1&campaign=newsletter&keyword=2013-11-19', $response->getContent());
     }
 
-    public function testWebViewAction_MailNotFound()
+    public function testWebViewActionMailNotFound()
     {
         $token = 'fdasdfasfafsadf-not-found';
         $twigMock = $this->getMockBuilder("Symfony\Bundle\TwigBundle\TwigEngine")->disableOriginalConstructor()->getMock();
@@ -369,7 +369,7 @@ class AzineEmailTemplateControllerTest extends WebTestCase
     /**
      * @expectedException \Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException
      */
-    public function testServeImageAction_404()
+    public function testServeImageAction404()
     {
         $folderKey = 'asdfadfasfasfd';
         $filename = 'testImage.not.found.png';

--- a/Tests/Services/AzineNotifierServiceTest.php
+++ b/Tests/Services/AzineNotifierServiceTest.php
@@ -95,7 +95,7 @@ class AzineNotifierServiceTest extends \PHPUnit\Framework\TestCase
         return true;
     }
 
-    public function testSendNewsletter_NoContent()
+    public function testSendNewsletterNoContent()
     {
         $failedAddresses = array();
         $recipientIds = array(11, 12, 13, 14);
@@ -140,7 +140,7 @@ class AzineNotifierServiceTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($sentMailCount, $sentMails, "Not the right number of emails has been sent successfully. Expected $sentMailCount");
     }
 
-    public function testSendNotificationsAzineNotifierService_NoNotifications()
+    public function testSendNotificationsAzineNotifierServiceNoNotifications()
     {
         $failedAddresses = array();
         $recipientIds = array(11, 12, 13, 14);

--- a/Tests/Services/AzineTwigSwiftMailerTest.php
+++ b/Tests/Services/AzineTwigSwiftMailerTest.php
@@ -285,7 +285,7 @@ class AzineTwigSwiftMailerTest extends \PHPUnit\Framework\TestCase
         $this->getMockBuilder("Azine\EmailBundle\Services\AzineTemplateProvider")->disableOriginalConstructor()->getMock();
 
         $mocks['entityManager'] = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $mocks['managerRegistry'] = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $mocks['managerRegistry'] = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $mocks['managerRegistry']->expects($this->any())->method('getManager')->will($this->returnValue($mocks['entityManager']));
 
         $mocks['parameters'] = array(AzineEmailExtension::NO_REPLY => array(

--- a/Tests/Services/AzineTwigSwiftMailerTest.php
+++ b/Tests/Services/AzineTwigSwiftMailerTest.php
@@ -285,7 +285,7 @@ class AzineTwigSwiftMailerTest extends \PHPUnit\Framework\TestCase
         $this->getMockBuilder("Azine\EmailBundle\Services\AzineTemplateProvider")->disableOriginalConstructor()->getMock();
 
         $mocks['entityManager'] = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $mocks['managerRegistry'] = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $mocks['managerRegistry'] = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $mocks['managerRegistry']->expects($this->any())->method('getManager')->will($this->returnValue($mocks['entityManager']));
 
         $mocks['parameters'] = array(AzineEmailExtension::NO_REPLY => array(

--- a/Tests/Services/AzineTwigSwiftMailerTest.php
+++ b/Tests/Services/AzineTwigSwiftMailerTest.php
@@ -111,7 +111,7 @@ class AzineTwigSwiftMailerTest extends \PHPUnit\Framework\TestCase
                 $generatedImage = "<img src='".$context['embededUsedGeneratedImage']."' alt='generatedImage'>";
             }
 
-            return  "<html><body><h1>a html body</h1>$generatedImage<a href='http://some.url.com/' ><img src='".$context['logo_png']."' alt='logo'></a><p>with a paragraph and <a href='https://foo.bar.com/index.php?q=4'>links</a>.</p></body><html>";
+            return "<html><body><h1>a html body</h1>$generatedImage<a href='http://some.url.com/' ><img src='".$context['logo_png']."' alt='logo'></a><p>with a paragraph and <a href='https://foo.bar.com/index.php?q=4'>links</a>.</p></body><html>";
         } elseif ('body_text' == $name) {
             return "a text body \n \n with new lines.";
         }

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": ">=5.6.0",
         "symfony/framework-bundle": "~2.7|^3.0|^4.0",
+        "symfony/config": "~2.7|^3.0|^4.0",
         "symfony/console": "~2.7|^3.0|^4.0",
         "symfony/finder": "~2.7|^3.0|^4.0",
         "symfony/twig-bundle": "~2.7|^3.0|^4.0",


### PR DESCRIPTION
The location of the locking classes changed for newer Symfony releases. This change works around this BC break.